### PR TITLE
Update opensource_eda_tool_install.sh

### DIFF
--- a/opensource_eda_tool_install.sh
+++ b/opensource_eda_tool_install.sh
@@ -113,5 +113,7 @@ sudo make
 cd ../
 sudo ln -s $PWD/bin/ot-shell /usr/bin/OpenTimer
 cd ../../
+sudo apt-get update
+sudo apt-get install python3-tk
 
 


### PR DESCRIPTION
I had faced error when opening qflow gui in ubuntu (22.04) but it was solved after installing python3-tk. So I think, the installation process will be easier if the last two lines are added in the script. Thanks